### PR TITLE
Increase JSON size limit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import preResponseLifecycleHook from "./routes/response.js";
 import tracer from "./tracing.js";
 
 export const app = express();
-app.use(express.json());
+app.use(express.json({limit: "50mb"}));
 
 app.post("/pre-parse", withTrace(tracer, "pre-parse", preParseLifecycleHook));
 app.post(


### PR DESCRIPTION
Large introspection queries are giving us errors like these: https://stackoverflow.com/questions/50304779/payloadtoolargeerror-request-entity-too-large

Increase body size limit to 50mb, default is 10kb: http://expressjs.com/en/api.html