### PR TITLE
Allow named operations, fix request validation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ export const Config = {
   // These queries can also be written over multiple lines with whatever
   // indentation you'd prefer, as the hashing key mechanism works in terms of
   // the parsed query, which doesn't preserve whitespace.
-  queries_to_cache: ["query { artist { name } }"],
+  queries_to_cache: ["query test { artist { name } }"],
 
   // The time for which a value will survive in the cache. After this, the
   // cache will be invalidated, and the next occurrence of the query will

--- a/src/request.js
+++ b/src/request.js
@@ -3,7 +3,7 @@ import { parse } from "graphql";
 // Parse a request to convert the request into an AST, and then use that AST
 // and the other information to produce a cache key.
 export const prepareRequest = (request) => {
-  const { query, ...req } = request.rawRequest;
+  const { query, operationName, ...req } = request.rawRequest;
   const parsed = parse(query);
   stripLocations(parsed);
 

--- a/src/types/parse.js
+++ b/src/types/parse.js
@@ -4,7 +4,7 @@ import Joi from "joi";
 export default Joi.object({
   rawRequest: Joi.object({
     query: Joi.string().min(1).required(),
-    variables: Joi.object().pattern(/^\w+$/, Joi.string()).allow(null),
+    variables: Joi.object().pattern(/^\w+$/, Joi.any()).allow(null),
     operationName: Joi.string().min(1).optional().allow(null),
   }),
 

--- a/src/types/response.js
+++ b/src/types/response.js
@@ -4,7 +4,7 @@ import Joi from "joi";
 export default Joi.object({
   rawRequest: Joi.object({
     query: Joi.string().min(1).required(),
-    variables: Joi.object().pattern(/^\w+$/, Joi.string()).allow(null),
+    variables: Joi.object().pattern(/^\w+$/, Joi.any()).allow(null),
     operationName: Joi.string().min(1).optional().allow(null),
   }),
 


### PR DESCRIPTION
A couple fixes after some user testing. Named operations cause problems because the name is both part of the request (`operationName`) _and_ the query itself (in the AST). Also, I got one of the types wrong - non-session variables can be anything, not just strings.