### PR TITLE
Specify a TTL per query

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,28 +84,19 @@ secret that the engine should send over in its requests.
 
 ```javascript
 queries_to_cache: [
-  "query { Artist { Name } }",
-  "query { Album { Artist { Name } } }",
+  { query: "query { Artist { Name } }", time_to_live: 60 },
+  { query: "query { Album { Artist { Name } } }", time_to_live: 120 }
 ];
 ```
 
 When a user makes a request to the server, the caching plugin will parse the
 request into an AST, and then check to see whether the AST matches the AST of
-any of these queries. If it does, the query will be cached. This means that
-whitespace is unimportant in these queries, and you can write them over
-multiple lines.
+any of these queries. If it does, the query will be cached for the given amount
+of time. This means that whitespace is unimportant in these queries, and you
+can write them over multiple lines.
 
 A result will be cached for each set of session and query variables that use
 this same query template.
-
-#### The `time_to_live` for a cache entry
-
-```javascript
-time_to_live: 600;
-```
-
-The length of time after which a given cache entry should be invalidated. This
-is measured in seconds.
 
 #### A `redis_url` for storing the cache entries.
 

--- a/src/config.js
+++ b/src/config.js
@@ -7,12 +7,15 @@ export const Config = {
   // These queries can also be written over multiple lines with whatever
   // indentation you'd prefer, as the hashing key mechanism works in terms of
   // the parsed query, which doesn't preserve whitespace.
-  queries_to_cache: ["query test { artist { name } }"],
+  queries_to_cache: [
+    { query: "query test { artist { name } }"
 
-  // The time for which a value will survive in the cache. After this, the
-  // cache will be invalidated, and the next occurrence of the query will
-  // repopulate the cache.
-  time_to_live: 600,
+      // The time for which a value will survive in the cache. After this, the
+      // cache will be invalidated, and the next occurrence of the query will
+      // repopulate the cache.
+    , time_to_live: 6
+    }
+  ],
 
   // The URL for a Redis instance.
   redis_url: "redis://redis:6379",

--- a/src/routes/response.js
+++ b/src/routes/response.js
@@ -44,7 +44,7 @@ export default async (request) => {
     });
   }
 
-  await writeEntryToCache(key, userResponse.value.response);
+  await writeEntryToCache(key, parsed, userResponse.value.response);
 
   return respond({
     attributes: { visibility: "user" },


### PR DESCRIPTION
Queries now come with TTLs. We look these TTLs up when we write to cache.

Easiest way to test this is to go into the `tests` folder and run `docker compose up`. Go to `localhost:8081`, run this query:

```
query test {
  artist {
    name
  }
}
```

Check the console output says the response is saved to cache. Wait seven seconds, run it again, it should be the same. Wait under six seconds, it should say that the value is already cached.