### PR TITLE
bugfix: fix missing `request.headers`

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -84,3 +84,16 @@ export const stripLocations = (abstractSyntaxTree) => {
       }
   }
 };
+
+// Add headers to a request object
+export const addHeadersToRequest = (request, headers) => {
+  // lowercase all header keys
+  const lowercasedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+
+  const requestWithHeaders = { ...request };
+  requestWithHeaders.headers = lowercasedHeaders;
+  return requestWithHeaders;
+};
+

--- a/src/routes/parse.js
+++ b/src/routes/parse.js
@@ -1,5 +1,5 @@
 import { Config } from "../config.js";
-import { prepareRequest } from "../request.js";
+import { addHeadersToRequest, prepareRequest } from "../request.js";
 import { lookupCacheEntry, shouldCache } from "../cache.js";
 
 import preParsePluginRequest from "../types/parse.js";
@@ -39,10 +39,7 @@ export default async (request) => {
 
   try {
     // Pass HTTP headers to the request for cache key generation
-    const requestWithHeaders = {
-      ...userRequest.value,
-      headers: request.headers
-    };
+    const requestWithHeaders = addHeadersToRequest(userRequest.value, request.headers);
 
     const { key, parsed } = prepareRequest(requestWithHeaders);
 

--- a/src/routes/response.js
+++ b/src/routes/response.js
@@ -1,5 +1,5 @@
 import { Config } from "../config.js";
-import { prepareRequest } from "../request.js";
+import { addHeadersToRequest, prepareRequest } from "../request.js";
 import { lookupCacheEntry, shouldCache, writeEntryToCache } from "../cache.js";
 
 import preResponsePluginRequest from "../types/response.js";
@@ -39,10 +39,7 @@ export default async (request) => {
 
   try {
     // Pass HTTP headers to the request for cache key generation
-    const requestWithHeaders = {
-      ...userResponse.value,
-      headers: request.headers
-    };
+    const requestWithHeaders = addHeadersToRequest(userResponse.value.request, request.headers);
 
     const { key, parsed } = prepareRequest(requestWithHeaders);
 


### PR DESCRIPTION
Fix the bug where the request was missing the headers, and thus the caching plugin was throwing an internal error.