### PR TITLE
propagate traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@opentelemetry/api": "^1.6.0",
         "@opentelemetry/instrumentation": "^0.54.0",
         "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/propagator-b3": "^2.0.1",
         "@opentelemetry/sdk-trace-node": "^1.27.0",
         "express": "^4.21.1",
         "graphql": "^16.9.0",
@@ -548,17 +549,42 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.27.0.tgz",
-      "integrity": "sha512-pTsko3gnMioe3FeWcwTQR3omo5C35tYsKKwjgTCTVCgd3EOWL9BZrMfgLBmszrwXABDfUrlAEFN/0W0FfQGynQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.0.1.tgz",
+      "integrity": "sha512-Hc09CaQ8Tf5AGLmf449H726uRoBNGPBL4bjr7AnnUpzWMvhdn61F78z9qb6IqB737TffBsokGAK1XykFEZ1igw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0"
+        "@opentelemetry/core": "2.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
+      "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
@@ -723,6 +749,21 @@
         "@opentelemetry/propagator-jaeger": "1.27.0",
         "@opentelemetry/sdk-trace-base": "1.27.0",
         "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.27.0.tgz",
+      "integrity": "sha512-pTsko3gnMioe3FeWcwTQR3omo5C35tYsKKwjgTCTVCgd3EOWL9BZrMfgLBmszrwXABDfUrlAEFN/0W0FfQGynQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.27.0"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@opentelemetry/api": "^1.6.0",
     "@opentelemetry/instrumentation": "^0.54.0",
     "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/propagator-b3": "^2.0.1",
     "@opentelemetry/sdk-trace-node": "^1.27.0",
     "express": "^4.21.1",
     "graphql": "^16.9.0",

--- a/src/routes/parse.js
+++ b/src/routes/parse.js
@@ -31,7 +31,7 @@ export default async (request) => {
     });
 
     return userError({
-      attributes: { visibility: null },
+      attributes: { "internal.visibility": null },
       response: { message: "bad request: " + userRequest.error },
       message: "bad request: " + userRequest.error,
     });
@@ -49,7 +49,7 @@ export default async (request) => {
       });
 
       return continue_({
-        attributes: { visibility: "user" },
+        attributes: { "internal.visibility": "user" },
         message: "query not listed as cacheable",
       });
     }
@@ -62,7 +62,7 @@ export default async (request) => {
       });
 
       return continue_({
-        attributes: { visibility: "user" },
+        attributes: { "internal.visibility": "user" },
         message: "found cacheable query with no current entry",
       });
     }
@@ -72,7 +72,7 @@ export default async (request) => {
     });
 
     return respond({
-      attributes: { visibility: "user" },
+      attributes: { "internal.visibility": "user" },
       response: JSON.parse(lookup),
       message: "found query response in cache",
     });

--- a/src/routes/response.js
+++ b/src/routes/response.js
@@ -31,7 +31,7 @@ export default async (request) => {
     });
 
     return userError({
-      attributes: { visibility: null },
+      attributes: { "internal.visibility": null },
       response: { message: "bad request: " + userResponse.error },
       message: "bad request: " + userResponse.error,
     });
@@ -49,7 +49,7 @@ export default async (request) => {
       });
 
       return respond({
-        attributes: { visibility: "user" },
+        attributes: { "internal.visibility": "user" },
         message: "nothing saved to cache",
       });
     }
@@ -62,7 +62,7 @@ export default async (request) => {
       });
 
       return respond({
-        attributes: { visibility: "user" },
+        attributes: { "internal.visibility": "user" },
         message: "value already cached",
       });
     }
@@ -74,7 +74,7 @@ export default async (request) => {
     });
 
     return respond({
-      attributes: { visibility: "user" },
+      attributes: { "internal.visibility": "user" },
       message: "saved response to cache",
     });
   } catch (error) {


### PR DESCRIPTION
This PR changes the plugin to propagate traces.

We have also changed the span attribute name from `visibility` to `internal.visibility`.

Before:
<img width="6003" height="3212" alt="image" src="https://github.com/user-attachments/assets/dd066739-19af-4051-9a3f-444902e385ad" />


After:
<img width="6003" height="3212" alt="image" src="https://github.com/user-attachments/assets/21c82ced-30eb-44d0-a2bb-6e6c9646141b" />
