### PR TITLE
Change base image to public ECR for express

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/express:latest
+FROM public.ecr.aws/bitnami/express:latest
 
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` by changing the base image source for the Express application. The new image source uses the public AWS ECR registry instead of the previous Bitnami registry.